### PR TITLE
Feature: maximum notifications onscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Configuration Defaults / Options
 * `nonblock: false` - Create a non-blocking notice. It lets the user click elements underneath it.
 * `nonblock_opacity: .2` - The opacity of the notice (if it's non-blocking) when the mouse is over it.
 * `history: true` - Display a pull down menu to redisplay previous notices, and place the notice in the history.
+* `maxonscreen: Infinity` - Maximum number of notifications to have onscreen.
 * `auto_display: true` - Display the notice when it is created. Turn this off to add notifications to the history without displaying them.
 * `width: "300px"` - Width of the notice.
 * `min_height: "16px"` - Minimum height of the notice. It will expand to fit content.

--- a/jquery.pnotify.js
+++ b/jquery.pnotify.js
@@ -504,6 +504,14 @@
 
 			// Display the notice.
 			pnotify.pnotify_display = function() {
+                // Remove oldest notifications leaving only opts.maxonscreen on screen
+                notices_data = jwindow.data("pnotify");
+                if (notices_data && (notices_data.length > opts.maxonscreen)) {
+                    $.each(notices_data.slice(0, notices_data.length - opts.maxonscreen), function(){
+                        if (this.pnotify_remove)
+                            this.pnotify_remove();
+                        });
+                };
 				// If the notice is not in the DOM, append it.
 				if (!pnotify.parent().length)
 					pnotify.appendTo(body);
@@ -873,6 +881,8 @@
 		nonblock_opacity: .2,
 		// Display a pull down menu to redisplay previous notices, and place the notice in the history.
 		history: true,
+        // Maximum number of notifications to have onscreen
+        maxonscreen: Infinity,
 		// Display the notice when it is created. Turn this off to add notifications to the history without displaying them.
 		auto_display: true,
 		// Width of the notice.


### PR DESCRIPTION
Added an option ("maxonscreen") to specify the maximum number of messages to display on screen.

The option can be set in $.pnotify.defaults and code was added to pnotify.pnotify_display that checks the length of jwindow.data('pnotify') and if necessary removes notifications (by calling pnotify_remove on items starting at the beginning of the array).

Let me know if you think this will be useful.

Awesome library!
