### PR TITLE
adding bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,9 @@
+{
+    "name": "pnotify",
+    "version": "1.2.2",
+    "main": [
+        "jquery.pnotify.js",
+        "jquery.pnotify.default.css",
+        "jquery.pnotify.icons.css"
+    ]
+}


### PR DESCRIPTION
[Bower](https://github.com/bower/bower) is really helpful to maintain dependencies. It would be nice if pnotify had the bower information file in its code.
