### PR TITLE
Fix for "All" and "Last" history buttons

### DIFF
--- a/jquery.pnotify.js
+++ b/jquery.pnotify.js
@@ -773,8 +773,11 @@
 								$(this).removeClass(styles.hi_btnhov);
 							},
 							"click": function(){
+								var pushTop = ($.pnotify.defaults.stack.push == "top");
+
 								// Look up the last history notice, and display it.
-								var i = -1;
+								var i = (pushTop ? 0 : -1);
+
 								var notice;
 								do {
 									if (i == -1)
@@ -782,11 +785,10 @@
 									else
 										notice = notices_data.slice(i, i+1);
 									if (!notice[0])
-										break;
-									i--;
+										return false;
+
+									i = (pushTop ? i + 1 : i - 1);
 								} while (!notice[0].pnotify_history || notice[0].is(":visible"));
-								if (!notice[0])
-									return false;
 								if (notice[0].pnotify_display)
 									notice[0].pnotify_display();
 								return false;


### PR DESCRIPTION
The history buttons were not working properly. They were referencing a capture variable `notices_data`, which got out of sync with the global collection of notices because $.merge returns a new instance on each pnotify call. Because of this, the buttons only worked on the first notification opened.

![image](https://f.cloud.github.com/assets/4964780/1912384/60211802-7d39-11e3-8ce6-3022d29d4ba1.png)
