### PR TITLE
Fix for #49 and #98

### DIFF
--- a/jquery.pnotify.js
+++ b/jquery.pnotify.js
@@ -610,12 +610,15 @@
 					// If we're supposed to remove the notice from the DOM, do it.
 					if (opts.remove)
 						pnotify.detach();
-					// Remove object from notices_data (issue #49)
-					var notices_data = jwindow.data("pnotify");
-					if (notices_data!=null) {
-						var idx = $.inArray(pnotify,notices_data);
-						if (idx!==-1) {
-							notices_data.splice(idx,1);
+					// Remove object from notices_data to prevent memory leak (issue #49)
+					// unless history is on
+					if (!opts.history) {
+						var notices_data = jwindow.data("pnotify");
+						if (notices_data!=null) {
+							var idx = $.inArray(pnotify,notices_data);
+							if (idx!==-1) {
+								notices_data.splice(idx,1);
+							}
 						}
 					}
 				});


### PR DESCRIPTION
Attempted to fix issues #49 and #98.
#49 was related to jwindow.data("pnotify") array keeping a reference to all notices ever posted. If history is not enabled, then there is no need for leaking the memory. Fix: unnecessary notices are now removed in pnotify_remove() if history is disabled.
#98 is related to the maxonscreen option check not supporting push: "top" ordering. The check expected oldest notices to always be found at the front of notices_data, but with push: "top" notices are in reverse order in the array.
