### PR TITLE
Allow dom objects to be directly appended

### DIFF
--- a/jquery.pnotify.js
+++ b/jquery.pnotify.js
@@ -760,6 +760,8 @@
 				pnotify.text_container.hide();
 			else if (opts.text_escape)
 				pnotify.text_container.text(opts.text);
+                        else if (typeof opts.text === "object")
+            			pnotify.text_container.append(opts.text).slideDown(200);
 			else
 				pnotify.text_container.html(opts.insert_brs ? String(opts.text).replace(/\n/g, "<br />") : opts.text);
 


### PR DESCRIPTION
Modified the text option to allow dom objects to be passed in, and appended to the text_container of the dropdown.  This allowed us to use angular.js compiled templates directly in a pnotify popup, without losing bindings.