### PR TITLE
Add a package.json for compatibility with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pnotify",
+  "version": "2.0.1",
+  "main": "pnotify.core.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sciactive/pnotify.git"
+  },
+  "author": "",
+  "license": "GPL LGPL and MPL",
+  "bugs": {
+    "url": "https://github.com/sciactive/pnotify/issues"
+  },
+  "homepage": "https://github.com/sciactive/pnotify"
+}


### PR DESCRIPTION
Even if you never publish to the npm registry, this will allow users like me to install pnotify with this command:

    npm install git://github.com/sciactive/pnotify.git

