### PR TITLE
Update pnotify.core.js

### DIFF
--- a/pnotify.core.js
+++ b/pnotify.core.js
@@ -175,7 +175,7 @@ license GPL/LGPL/MPL
 				},
 				"mouseleave": function(e){
 					// Start the close timer.
-					if (that.options.hide && that.options.mouse_reset) that.queueRemove();
+					if (that.options.hide && that.options.mouse_reset && message.animating !== "out") that.queueRemove();
 					PNotify.positionAll();
 				}
 			});


### PR DESCRIPTION
The mouseleave event which is setup to reset the timer doesn't catch the close click. If you click close and quickly move the cursor out the close button hides but the message is still present until the timer runs out. Add a check to see if the message is not animating to restart the timer.
