### PR TITLE
fixes <IE9 bug when console isn't open

### DIFF
--- a/pnotify.history.js
+++ b/pnotify.history.js
@@ -123,7 +123,6 @@
 					.appendTo(history_menu);
 
 					// Get the top of the handle.
-					console.log(handle.offset());
 					history_handle_top = handle.offset().top + 2;
 					// Hide the history pull down up to the top of the handle.
 					history_menu.css({top: "-"+history_handle_top+"px"});


### PR DESCRIPTION
having console.log in the code causing IE8 and IE9 to break when the developer tools aren't open, I don't see any reason for it to be there anyway.
