### PR TITLE
Added support for screen reader

### DIFF
--- a/pnotify.core.js
+++ b/pnotify.core.js
@@ -181,8 +181,10 @@ license GPL/LGPL/MPL
 				}
 			});
 			// Create a container for the notice contents.
-			this.container = $("<div />", {"class": this.styles.container+" ui-pnotify-container "+(this.options.type === "error" ? this.styles.error : (this.options.type === "info" ? this.styles.info : (this.options.type === "success" ? this.styles.success : this.styles.notice)))})
-			.appendTo(this.elem);
+			this.container = $("<div />", {
+				"class": this.styles.container+" ui-pnotify-container "+(this.options.type === "error" ? this.styles.error : (this.options.type === "info" ? this.styles.info : (this.options.type === "success" ? this.styles.success : this.styles.notice))),
+				"role": "alert"
+			}).appendTo(this.elem);
 			if (this.options.cornerclass !== "")
 				this.container.removeClass("ui-corner-all").addClass(this.options.cornerclass);
 			// Create a drop shadow.
@@ -211,8 +213,7 @@ license GPL/LGPL/MPL
 
 			// Add text.
 			this.text_container = $("<div />", {
-				"class": "ui-pnotify-text",
-				"role": "alert"
+				"class": "ui-pnotify-text"
 			})
 			.appendTo(this.container);
 			if (this.options.text === false)

--- a/pnotify.core.js
+++ b/pnotify.core.js
@@ -164,6 +164,7 @@ license GPL/LGPL/MPL
 			this.elem = $("<div />", {
 				"class": "ui-pnotify "+this.options.addclass,
 				"css": {"display": "none"},
+        "aria-live": "assertive",
 				"mouseenter": function(e){
 					if (that.options.mouse_reset && that.animating === "out") {
 						if (!that.timerHide)
@@ -210,7 +211,8 @@ license GPL/LGPL/MPL
 
 			// Add text.
 			this.text_container = $("<div />", {
-				"class": "ui-pnotify-text"
+				"class": "ui-pnotify-text",
+        "role": "alert"
 			})
 			.appendTo(this.container);
 			if (this.options.text === false)

--- a/pnotify.core.js
+++ b/pnotify.core.js
@@ -164,7 +164,7 @@ license GPL/LGPL/MPL
 			this.elem = $("<div />", {
 				"class": "ui-pnotify "+this.options.addclass,
 				"css": {"display": "none"},
-        "aria-live": "assertive",
+				"aria-live": "assertive",
 				"mouseenter": function(e){
 					if (that.options.mouse_reset && that.animating === "out") {
 						if (!that.timerHide)
@@ -212,7 +212,7 @@ license GPL/LGPL/MPL
 			// Add text.
 			this.text_container = $("<div />", {
 				"class": "ui-pnotify-text",
-        "role": "alert"
+				"role": "alert"
 			})
 			.appendTo(this.container);
 			if (this.options.text === false)


### PR DESCRIPTION
Implemented an aria-live region to the notification stack and a role="alert" attribute to the notification container so that the screen reader notice the notification and read it to the user.

see also https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions