### PR TITLE
Added licensing information to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,5 +38,6 @@
         "src/pnotify.tooltip.min.js",
         "src/pnotify.mobile.js",
         "src/pnotify.mobile.min.js"
-    ]
+    ],
+    "license": ["GPL-3.0", "LGPL-3.0", "MPL-1.1"]
 }


### PR DESCRIPTION
To support libraries that inspect and generate information about all the libraries used in the project (e.g. `grunt-license-bower`).

See: http://bower.io/docs/creating-packages/