### PR TITLE
Fix CommonJS in modules.

### DIFF
--- a/src/pnotify.animate.js
+++ b/src/pnotify.animate.js
@@ -105,4 +105,5 @@
             this.notice.elem.one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', callback).removeClass(this.options.in_class).addClass(this.options.out_class);
         }
     };
+    return PNotify;
 }));

--- a/src/pnotify.buttons.js
+++ b/src/pnotify.buttons.js
@@ -173,4 +173,5 @@
         pin_up: "fa fa-pause",
         pin_down: "fa fa-play"
     });
+    return PNotify;
 }));

--- a/src/pnotify.callbacks.js
+++ b/src/pnotify.callbacks.js
@@ -47,4 +47,5 @@
             }
         }
     };
+    return PNotify;
 }));

--- a/src/pnotify.confirm.js
+++ b/src/pnotify.confirm.js
@@ -155,4 +155,5 @@
         btn: "btn btn-default",
         input: "form-control"
     });
+    return PNotify;
 }));

--- a/src/pnotify.desktop.js
+++ b/src/pnotify.desktop.js
@@ -151,4 +151,5 @@
         }
     };
     permission = PNotify.desktop.checkPermission();
+    return PNotify;
 }));

--- a/src/pnotify.history.js
+++ b/src/pnotify.history.js
@@ -187,4 +187,5 @@
         hi_btnhov: "",
         hi_hnd: "fa fa-chevron-down"
     });
+    return PNotify;
 }));

--- a/src/pnotify.mobile.js
+++ b/src/pnotify.mobile.js
@@ -118,4 +118,5 @@
             }
         }
     };
+    return PNotify;
 }));

--- a/src/pnotify.nonblock.js
+++ b/src/pnotify.nonblock.js
@@ -153,4 +153,5 @@
             });
         }
     };
+    return PNotify;
 }));

--- a/src/pnotify.reference.js
+++ b/src/pnotify.reference.js
@@ -144,4 +144,6 @@
     $.extend(PNotify.styling.fontawesome, {
         athing: "fa fa-refresh"
     });
+    // Return PNotify for CommonJS modules.
+    return PNotify;
 }));

--- a/src/pnotify.tooltip.js
+++ b/src/pnotify.tooltip.js
@@ -11,5 +11,5 @@
         factory(root.jQuery, root.PNotify);
     }
 }(this, function($, PNotify){
-
+    return PNotify;
 }));


### PR DESCRIPTION
The combined file with multiple modules shares a single `module.exports`, so all modules must export PNotify so PNotify is not left `undefined` by the end of the script.
