### PR TITLE
Fix for automated builds

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "pnotify",
   "description": "JavaScript notification plugin.",
   "main": [
+    "dist/pnotify.js",
     "dist/pnotify.animate.js",
     "dist/pnotify.brighttheme.css",
     "dist/pnotify.buttons.css",
@@ -9,7 +10,6 @@
     "dist/pnotify.callbacks.js",
     "dist/pnotify.confirm.js",
     "dist/pnotify.css",
-    "dist/pnotify.js",
     "dist/pnotify.desktop.js",
     "dist/pnotify.history.css",
     "dist/pnotify.history.js",


### PR DESCRIPTION
In bower.json, since the `pnotify.js` was defined after its dependencies, it was breaking the build process of gulp. This is a minor commit that fixes this issue.