### PR TITLE
Fix the attention function in animate

### DIFF
--- a/src/pnotify.animate.js
+++ b/src/pnotify.animate.js
@@ -79,6 +79,7 @@
             this.notice.animating = "in";
             var that = this;
             callback = (function(){
+                that.notice.elem.removeClass(that.options.in_class);
                 if (this) {
                     this.call();
                 }
@@ -94,7 +95,7 @@
             this.notice.animating = "out";
             var that = this;
             callback = (function(){
-                that.notice.elem.removeClass("ui-pnotify-in");
+                that.notice.elem.removeClass("ui-pnotify-in " + that.options.out_class);
                 if (this) {
                     this.call();
                 }


### PR DESCRIPTION
If the in/out classes are left on, they will prevent attention from working.