### PR TITLE
Update PNotifyConfirm.html

### DIFF
--- a/src/PNotifyConfirm.html
+++ b/src/PNotifyConfirm.html
@@ -175,11 +175,11 @@
             let i = buttons.length - 1;
             while (i >= 0) {
               if (buttons[i].promptTrigger) {
+                this.refs.buttons.children[i].focus();
                 break;
               }
               i--;
             }
-            this.refs.buttons.children[i].focus();
           }
         }
       },


### PR DESCRIPTION
Will throw a TypeError exception "Cannot read property 'focus' of undefined" if none of the buttons has promptTrigger, because in that case i = -1 by the time we get to line this.refs.buttons.children[i].focus();.