### PR TITLE
Fix typing of Stack for TypeScript 3.9.2

### DIFF
--- a/packages/core/Stack.d.ts
+++ b/packages/core/Stack.d.ts
@@ -118,7 +118,7 @@ export default class Stack extends StackProperties {
    * An "array" of notices. It's actually built on the fly from the double
    * linked list the notices are actually stored in.
    */
-  readonly notices: Notice[];
+  readonly notices: (typeof Notice)[];
   /**
    * How many notices there are in the stack.
    */
@@ -127,7 +127,7 @@ export default class Stack extends StackProperties {
    * When a stack is modalish, this is the notice that is open in the non-modal
    * state.
    */
-  readonly leader: Notice | null;
+  readonly leader: typeof Notice | null;
 
   constructor(options: StackOptions);
 
@@ -139,14 +139,14 @@ export default class Stack extends StackProperties {
    * @param options Controls which direction to iterate notices.
    */
   forEach(
-    callback: (notice?: Notice) => void,
+    callback: (notice?: typeof Notice) => void,
     options?: {
       /**
        * Where to start the iteration.
        *
        * @default 'oldest'
        */
-      start: Notice | 'head' | 'tail' | 'oldest' | 'newest';
+      start: typeof Notice | 'head' | 'tail' | 'oldest' | 'newest';
       /**
        * Which direction in the double linked list to iterate.
        *


### PR DESCRIPTION
Hello, when using pnotify with project in typesciprt 3.9.2 I've got error
``` ｢atl｣: Checking started in a separate process...
[at-loader] ./node_modules/@pnotify/core/Stack.d.ts:121:21 
    TS2709: Cannot use namespace 'Notice' as a type. 

[at-loader] ./node_modules/@pnotify/core/Stack.d.ts:130:20 
    TS2709: Cannot use namespace 'Notice' as a type. 

[at-loader] ./node_modules/@pnotify/core/Stack.d.ts:142:25 
    TS2709: Cannot use namespace 'Notice' as a type. 

[at-loader] ./node_modules/@pnotify/core/Stack.d.ts:149:14 
    TS2709: Cannot use namespace 'Notice' as a type. ```

So I've prepared fix for this - use proper typeof in Stack.d.ts