### PR TITLE
Exporting NoticeProperties type directly

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -2,7 +2,7 @@ import Stack, { StackProperties, StackOptions } from './Stack.js';
 
 export as namespace PNotify;
 
-declare abstract class NoticeProperties {
+export declare abstract class NoticeProperties {
   /**
    * Type of the notice. 'notice', 'info', 'success', or 'error'.
    *


### PR DESCRIPTION
I was noticing `Exported variable <variable name> has or is using private name <private name>` issue for `NoticeProperties` in my project. This PR will export this class so that the compiler can reference it.

See: https://github.com/microsoft/TypeScript/issues/6307